### PR TITLE
properly decode response

### DIFF
--- a/pypushwoosh/client.py
+++ b/pypushwoosh/client.py
@@ -48,4 +48,4 @@ class PushwooshClient(PushwooshBaseClient):
             log.debug('Response headers: %s' % response.getheaders())
 
         body = response.read()
-        return json.loads(body)
+        return json.loads(body.decode('utf-8'))


### PR DESCRIPTION
In python3 generates error because response has a type 'bytes' but json.loads required 'str'