### PR TITLE
Adds support for users property of createMessage notification

### DIFF
--- a/pypushwoosh/notification.py
+++ b/pypushwoosh/notification.py
@@ -66,13 +66,14 @@ class CommonNotificationMixin(BaseNotificationMixin):
         self.link = None
         self.minimize_link = constants.LINK_MINIMIZER_GOOGLE
         self.data = None
+        self.users = None
 
     def render(self):
         result = {
             'send_date': self.send_date,
             'content': self.content,
         }
-        render_attrs(self, result, ('ignore_user_timezone', 'page_id', 'link', 'data'))
+        render_attrs(self, result, ('ignore_user_timezone', 'page_id', 'link', 'data', 'users'))
 
         if 'link' in result:
             result['minimize_link'] = self.minimize_link

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -62,6 +62,29 @@ class TestCreateMessageCommand(unittest.TestCase):
         command_dict = json.loads(self.command.render())
         self.assertDictEqual(command_dict, expected_result)
 
+    def test_valid_create_by_user(self):
+        users_list = ['user_1', 'user_2']
+        expected_result = {
+            'request': {
+                'application': self.code,
+                'auth': self.auth,
+                'notifications': [
+                    {
+                        'content': 'Hello world!',
+                        'send_date': 'now',
+                        'users': users_list,
+                    }
+                ]
+            }
+        }
+
+        self.notification.users = users_list
+        self.command = CreateMessageForApplicationCommand(self.notification, application=self.code)
+        self.command.auth = self.auth
+
+        command_dict = json.loads(self.command.render())
+        self.assertDictEqual(command_dict, expected_result)
+
     def test_create_message_without_application(self):
         self.command = CreateMessageForApplicationCommand(self.notification)
         self.command.auth = self.auth


### PR DESCRIPTION
Addresses an issue with user-centric push notifications using the `users` filter in conjunction with registerUser. 

The `users` item of the “Notification” class is not being included when the payload is being rendered for the createMessage request. The result of which is the `users` property not being included, the `users` filters is not applied, and a broadcast message to all users is sent instead of a single message. The solution is to add `users` to the `CommonNotificationMixin`.

https://www.pushwoosh.com/reference/#createmessage 